### PR TITLE
Adds aws profile switcher script

### DIFF
--- a/aws/aws-profile
+++ b/aws/aws-profile
@@ -1,0 +1,154 @@
+#!/usr/bin/env ruby
+
+# Usage: Put the following in your bashrc or zshrc:
+# $ eval $(aws-profile --env)
+#
+# Switch aws profiles with:
+# $ awsp <profile>
+
+def load_gem(name, version=nil)
+  begin
+    gem name, version
+  rescue LoadError
+    $stderr.puts "Please run `gem install #{name}` before using this script."
+    exit 0
+  end
+
+  require name
+end
+
+load_gem 'aws-sdk-core'
+require 'yaml'
+
+class String
+  def black;          "%F{black}#{self}%f" end
+  def red;            "%F{red}#{self}%f" end
+  def green;          "%F{green}#{self}%f" end
+  def brown;          "%F{brown}#{self}%f" end
+  def blue;           "%F{blue}#{self}%f" end
+  def magenta;        "%F{magenta}#{self}%f" end
+  def cyan;           "%F{cyan}#{self}%f" end
+  def gray;           "%F{gray}#{self}%f" end
+  def yellow;         "%F{yellow}#{self}%f" end
+  def none;           self end
+end
+
+def profile_rprompt(profile_name)
+  if profile = PROFILES[profile_name]
+    profile_name.send(profile['color'] || 'none')
+  else
+    "UNSET"
+  end
+end
+
+def set_or_unset(env, val)
+  if val
+    "export #{env}=#{val}"
+  else
+    "unset #{env}"
+  end
+end
+
+def parse_ini(string)
+  ret = {}
+  section = {}
+  string.lines.each do |line|
+    case line
+    when /\s*\[(.*)\]\s*(;.*)?/
+      section = {}
+      ret[$1.strip] = section
+    when /(.*?)=(.*)(;.*)?/
+      key = $1.dup
+      val = $2.dup
+      section[key.strip.gsub(/^aws_/, '').to_sym] = val.strip
+    end
+  end
+  ret
+end
+
+def mfa_prompt(profile_name)
+  $stderr.print "Enter MFA Code for #{profile_name}: "
+  STDOUT.flush
+  $stdin.gets.chomp
+end
+
+if ARGV.size != 1
+  $stderr.puts "Usage: aws-profile <profile>"
+end
+
+case ARGV.first
+when '--env'
+  puts <<-EOF
+awsp () {
+        $(aws-profile $1)
+}
+  EOF
+  exit 0
+end
+
+profile_name = ARGV.first || ENV['AWS_PROFILE'] || ENV['AWS_DEFAULT_PROFILE'] || 'default'
+credentials_file = "#{ENV['AWS_HOME'] || ENV['HOME'] + '/.aws'}/credentials"
+sessions_file = "#{ENV['AWS_HOME'] || ENV['HOME'] + '/.aws'}/sessions"
+
+PROFILES = parse_ini(File.read(credentials_file))
+SESSIONS = YAML.load(File.read(sessions_file)) || {} rescue {}
+
+def load_credentials(profile_name)
+  profile = PROFILES[profile_name] || raise("No such profile #{profile_name}")
+
+  if session = SESSIONS[profile_name]
+    if (Time.now.to_i + 5 * 60) > session[:expiration].to_i
+      session = nil
+    end
+  end
+
+  if session.nil?
+    if source_profile = profile[:source_profile]
+      source_creds = load_credentials(source_profile)
+      sts = Aws::STS::Client.new(source_creds.select { |k, v| [:access_key_id, :secret_access_key, :session_token].include?(k) })
+
+      role_credentials_options = {
+        role_session_name: [*('A'..'Z')].sample(16).join,
+        role_arn: profile[:role_arn]
+      }
+
+      if profile[:mfa_serial]
+        role_credentials_options[:serial_number] ||= profile[:mfa_serial]
+        role_credentials_options[:token_code] ||= mfa_prompt(source_profile)
+      end
+
+      session_creds = sts.assume_role(role_credentials_options).credentials.to_h
+      session_creds[:region] ||= source_creds[:region]
+
+      SESSIONS[profile_name] = session_creds
+    else
+      if profile[:mfa_serial]
+        sts = Aws::STS::Client.new(profile.select { |k, v| [:access_key_id, :secret_access_key, :session_token].include?(k) })
+        session_creds = sts.get_session_token(serial_number: profile[:mfa_serial], token_code: mfa_prompt(profile_name)).credentials.to_h
+        session_creds[:region] ||= profile[:region]
+        SESSIONS[profile_name] = session_creds
+      else
+        profile
+      end
+    end
+  else
+    session
+  end
+end
+
+begin
+  creds = load_credentials(profile_name)
+rescue Exception => e
+  $stderr.puts e
+  exit 1
+end
+
+File.write(sessions_file, YAML.dump(SESSIONS))
+
+puts set_or_unset("AWS_DEFAULT_PROFILE", profile_name)
+puts set_or_unset("AWS_DEFAULT_REGION", creds[:region])
+puts set_or_unset("AWS_ACCESS_KEY_ID", creds[:access_key_id])
+puts set_or_unset("AWS_SECRET_ACCESS_KEY", creds[:secret_access_key])
+puts set_or_unset("AWS_SESSION_TOKEN", creds[:session_token])
+puts set_or_unset("AWS_RPROMPT", profile_rprompt(profile_name))
+


### PR DESCRIPTION
This script supports assume-role and create-session-token in aws credentials files, and exports AWS environment variables for the temporary session so that other tools can use those credentials easily.